### PR TITLE
Introduce dock in footer.qml and add mechanism to switch between two interface modes in settings

### DIFF
--- a/src/qml/Footer.qml
+++ b/src/qml/Footer.qml
@@ -19,7 +19,7 @@ Item {
     readonly property int maxVisibleItems: 5
 
     readonly property int visibleCount:
-        Math.min(launcherApps.count - 1, maxVisibleItems)
+        Math.min(launcherApps.rowCount() - 1, maxVisibleItems)
 
     height: (baseCellSize * root.dockScale) + 16
 

--- a/src/qml/Footer.qml
+++ b/src/qml/Footer.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import Cutie
 import Cutie.Wlc
 import Cutie.Store
+import Cutie.Wlc
 
 Item {
     id: footer
@@ -33,6 +34,7 @@ Item {
     Rectangle {
         color: Atmosphere.secondaryAlphaColor
         radius: 15
+        opacity: 1.0 - cutieWlc.blur
         width: root.panelMode ? parent.width : Math.min(parent.width,
             (baseCellSize * visibleCount) + (launchAppList.spacing * Math.max(visibleCount - 1, 0)))
 

--- a/src/qml/Footer.qml
+++ b/src/qml/Footer.qml
@@ -6,21 +6,47 @@ import Cutie.Store
 
 Item {
     id: footer
+
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.bottom: parent.bottom
-    anchors.leftMargin: 8
-    anchors.rightMargin: 8
-    anchors.bottomMargin: 8
-    opacity: 0
+    anchors.margins: 8
     z: 1
+    
+    readonly property real baseCellSize:
+        appSwitcher.width / Math.floor(appSwitcher.width / 51)
 
-    height: appSwitcher.width / Math.floor(appSwitcher.width / 51) + 16
+    readonly property int maxVisibleItems: 5
+
+    readonly property int visibleCount:
+        Math.min(launcherApps.count - 1, maxVisibleItems)
+
+    height: (baseCellSize * root.dockScale) + 16
+
+    Behavior on height {
+        NumberAnimation {
+            duration: 200
+            easing.type: Easing.OutCubic
+        }
+    }
 
     Rectangle {
         color: Atmosphere.secondaryAlphaColor
         radius: 15
-        anchors.fill: parent
+        width: root.panelMode ? parent.width : Math.min(parent.width,
+            (baseCellSize * visibleCount) + (launchAppList.spacing * Math.max(visibleCount - 1, 0)))
+
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+
+        Behavior on width {
+            NumberAnimation {
+                duration: 200
+                easing.type: Easing.OutCubic
+            }
+        }
 
         ListView {
             id: launchAppList
@@ -35,14 +61,24 @@ Item {
             spacing: 20
 
             delegate: Item {
-                width: appSwitcher.width / Math.floor(appSwitcher.width / 51)
+                width: baseCellSize * root.dockScale
                 height: width
+
+                Behavior on width {
+                    NumberAnimation {
+                        duration: 200
+                        easing.type: Easing.OutCubic
+                    }
+                }
 
                 CutieButton {
                     width: parent.height
                     height: width
                     icon.name: model.icon
                     icon.source: "file://" + model.icon
+                    icon.width: width
+                    icon.height: height
+
                     background: null
 
                     onClicked: cutieWlc.execApp(model.exec)

--- a/src/qml/Footer.qml
+++ b/src/qml/Footer.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls
 import Cutie
 import Cutie.Wlc
 import Cutie.Store
-import Cutie.Wlc
 
 Item {
     id: footer
@@ -20,7 +19,7 @@ Item {
     readonly property int maxVisibleItems: 5
 
     readonly property int visibleCount:
-        Math.min(launcherApps.rowCount() - 1, maxVisibleItems)
+        Math.min(launcherApps.rowCount(), maxVisibleItems)
 
     height: (baseCellSize * root.dockScale) + 16
 

--- a/src/qml/Footer.qml
+++ b/src/qml/Footer.qml
@@ -1,0 +1,68 @@
+import QtQuick
+import QtQuick.Controls
+import Cutie
+import Cutie.Wlc
+import Cutie.Store
+
+Item {
+    id: footer
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    anchors.leftMargin: 8
+    anchors.rightMargin: 8
+    anchors.bottomMargin: 8
+    opacity: 0
+    z: 1
+
+    height: appSwitcher.width / Math.floor(appSwitcher.width / 51) + 16
+
+    Rectangle {
+        color: Atmosphere.secondaryAlphaColor
+        radius: 15
+        anchors.fill: parent
+
+        ListView {
+            id: launchAppList
+            model: launcherApps
+            anchors.fill: parent
+            anchors.topMargin: 8
+            anchors.bottomMargin: 8
+            anchors.leftMargin: 1
+            anchors.rightMargin: 1
+            orientation: Qt.Horizontal
+            clip: true
+            spacing: 20
+
+            delegate: Item {
+                width: appSwitcher.width / Math.floor(appSwitcher.width / 51)
+                height: width
+
+                CutieButton {
+                    width: parent.height
+                    height: width
+                    icon.name: model.icon
+                    icon.source: "file://" + model.icon
+                    background: null
+
+                    onClicked: cutieWlc.execApp(model.exec)
+                    onPressAndHold: menu.open()
+                }
+
+                CutieMenu {
+                    id: menu
+                    width: appSwitcher.width * 2 / 3
+
+                    CutieMenuItem {
+                        text: qsTr("Remove from favorites")
+                        onTriggered: {
+                            let data = favoriteStore.data
+                            delete data[model.name]
+                            favoriteStore.data = data
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/qml/HomeScreen.qml
+++ b/src/qml/HomeScreen.qml
@@ -1,0 +1,84 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import QtQuick.Controls
+import Cutie
+import Cutie.Wlc
+import Cutie.Desktopfileparser
+import Cutie.Store
+
+Item {
+    id: homeScreen
+    anchors.fill: parent
+    opacity: 0
+    enabled: root.state == "homeScreen" 
+
+    CutieWlc { id: compositor }
+
+    // Favorite Apps Container
+    Rectangle {
+        opacity: 1.0 - cutieWlc.blur
+        visible: favoriteAppsVisibility
+        color: Atmosphere.secondaryAlphaColor
+        height: appSwitcher.width / Math.floor(appSwitcher.width / 51) + 16
+        radius: 15
+        z: 1
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.rightMargin: 8
+        anchors.leftMargin: 8
+        anchors.bottomMargin: 8
+        anchors.bottom: parent.bottom
+
+        ListView {
+            id: launchAppList
+            model: launcherApps 
+            anchors.fill: parent
+            anchors.topMargin: 8
+            anchors.bottomMargin: 8
+            anchors.leftMargin: 1
+            anchors.rightMargin: 1
+            orientation: Qt.Horizontal
+            clip: true
+            spacing: 20
+
+            delegate: Item {
+                width: appSwitcher.width / Math.floor(appSwitcher.width / 51)
+                height: width
+
+                CutieButton {
+                    id: appIconButton
+                    width: parent.height
+                    height: width
+                    icon.name: model.icon
+                    icon.source: "file://" + model.icon
+                    icon.height: height
+                    icon.width: height
+                    background: null
+
+                    onClicked: compositor.execApp(model.exec)
+                    onPressAndHold: menu.open()
+                }
+
+                CutieMenu {
+                    id: menu
+                    opacity: 1.0 - cutieWlc.blur
+                    width: appSwitcher.width * 2 / 3
+
+                    CutieMenuItem {
+                        text: qsTr("Remove from favorites")
+                        onTriggered: {
+                            let data = favoriteStore.data;
+                            let appName = model.name;
+                            
+                            if (data.hasOwnProperty(appName)) {
+                                delete data[appName];
+                                console.log("home - Removed favorite app:", appName);
+                                favoriteStore.data = data; 
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/qml/HomeScreen.qml
+++ b/src/qml/HomeScreen.qml
@@ -1,84 +1,10 @@
 import QtQuick
-import Qt5Compat.GraphicalEffects
-import QtQuick.Controls
 import Cutie
 import Cutie.Wlc
-import Cutie.Desktopfileparser
-import Cutie.Store
 
 Item {
     id: homeScreen
     anchors.fill: parent
     opacity: 0
-    enabled: root.state == "homeScreen" 
-
-    CutieWlc { id: compositor }
-
-    // Favorite Apps Container
-    Rectangle {
-        opacity: 1.0 - cutieWlc.blur
-        visible: favoriteAppsVisibility
-        color: Atmosphere.secondaryAlphaColor
-        height: appSwitcher.width / Math.floor(appSwitcher.width / 51) + 16
-        radius: 15
-        z: 1
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.rightMargin: 8
-        anchors.leftMargin: 8
-        anchors.bottomMargin: 8
-        anchors.bottom: parent.bottom
-
-        ListView {
-            id: launchAppList
-            model: launcherApps 
-            anchors.fill: parent
-            anchors.topMargin: 8
-            anchors.bottomMargin: 8
-            anchors.leftMargin: 1
-            anchors.rightMargin: 1
-            orientation: Qt.Horizontal
-            clip: true
-            spacing: 20
-
-            delegate: Item {
-                width: appSwitcher.width / Math.floor(appSwitcher.width / 51)
-                height: width
-
-                CutieButton {
-                    id: appIconButton
-                    width: parent.height
-                    height: width
-                    icon.name: model.icon
-                    icon.source: "file://" + model.icon
-                    icon.height: height
-                    icon.width: height
-                    background: null
-
-                    onClicked: compositor.execApp(model.exec)
-                    onPressAndHold: menu.open()
-                }
-
-                CutieMenu {
-                    id: menu
-                    opacity: 1.0 - cutieWlc.blur
-                    width: appSwitcher.width * 2 / 3
-
-                    CutieMenuItem {
-                        text: qsTr("Remove from favorites")
-                        onTriggered: {
-                            let data = favoriteStore.data;
-                            let appName = model.name;
-                            
-                            if (data.hasOwnProperty(appName)) {
-                                delete data[appName];
-                                console.log("home - Removed favorite app:", appName);
-                                favoriteStore.data = data; 
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+    enabled: root.state == "homeScreen"
 }

--- a/src/qml/ScreenSwipe.qml
+++ b/src/qml/ScreenSwipe.qml
@@ -5,18 +5,17 @@ Item {
         x: 0
         y: 0
         height: root.height
-        width: 20
+        width: 25
 
         MouseArea { 
             drag.target: parent; drag.axis: Drag.XAxis; drag.minimumX: 0; drag.maximumX: root.width
             anchors.fill: parent
 
             function getNextState() {
-                if (root.state == "appSwitcher")
+                if (root.state == "homeScreen")
                     return "notificationScreen";
-                else if (root.state == "notificationScreen")
-                    return "appSwitcher";
-                else return "";
+                else 
+                    return "homeScreen";
             }
 
             onReleased: {
@@ -43,21 +42,20 @@ Item {
     }
 
     Item {
-        x: root.width - 20
+        x: root.width - 25
         y: 0
         height: root.height
-        width: 20
+        width: 25
 
         MouseArea { 
             drag.target: parent; drag.axis: Drag.XAxis; drag.minimumX: -20; drag.maximumX: root.width - 20
             anchors.fill: parent
 
             function getNextState() {
-                if (root.state == "appSwitcher")
-                    return "notificationScreen";
-                else if (root.state == "notificationScreen")
+                if (root.state == "homeScreen")
                     return "appSwitcher";
-                else return "";
+                else
+                    return "homeScreen";
             }
 
             onReleased: {

--- a/src/qml/ScreenSwipe.qml
+++ b/src/qml/ScreenSwipe.qml
@@ -12,6 +12,12 @@ Item {
             anchors.fill: parent
 
             function getNextState() {
+                if (root.interfaceMode==merged && root.state=="notificationScreen")
+                    return "appSwitcher"
+
+                if (root.interfaceMode==merged && root.state=="appSwitcher")
+                    return "notificationScreen"
+                    
                 if (root.state == "homeScreen")
                     return "notificationScreen";
                 else 
@@ -52,6 +58,12 @@ Item {
             anchors.fill: parent
 
             function getNextState() {
+                if (root.interfaceMode==merged && root.state=="appSwitcher")
+                    return "notificationScreen"
+
+                if (root.interfaceMode==merged && root.state=="notificationScreen")
+                    return "appSwitcher"
+
                 if (root.state == "homeScreen")
                     return "appSwitcher";
                 else

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -50,69 +50,11 @@ Item {
 
         }
     ]
-
-    function addNotification(title, body, id) {
-        notifications.append({title: title, body: body, id: id});
-        CutieFeedback.trigger(Application.name, "message-new-instant", {}, -1);
-    }
-
-    function delNotification(id) {
-        for (let c_i = 0; c_i < notifications.count; c_i++){
-            if (notifications.get(c_i).id === id)
-                notifications.remove(c_i);
-        }
-    }
-
-    function loadFavoriteApps() {
-        console.log("home - Loading Favorite store data using DesktopFileParser...");
-        if (!favoriteStore.data) {
-            console.log("home - Favorite store data is not yet available.");
-            return;
-        }
-        launcherApps.clear();
-        let favoriteKeys = Object.keys(favoriteStore.data);
-        let allAppsModel = CutieDesktopFileParser.fetchAllEntriesModel();
-        if (!allAppsModel) {
-            console.log("home - Error: DesktopFileParser model is null.");
-            return;
-        }
-        console.log("allAppsModel received count:", allAppsModel.rowCount());
-        for (let i = 0; i < allAppsModel.rowCount(); i++) {
-            let index = allAppsModel.index(i, 0);
-            let appName = allAppsModel.data(index, 257);
-            if (favoriteKeys.indexOf(appName) !== -1) {
-                launcherApps.append({
-                    name: appName,
-                    icon: allAppsModel.data(index, 259),
-                    exec: allAppsModel.data(index, 258)
-                });
-            }
-        }
-        console.log("home - Favorite apps loaded successfully. Count:", launcherApps.count);
-    }
-
-
-    Component.onCompleted: {
-        loadFavoriteApps();
-    }
-
-    CutieStore {
-        id: favoriteStore
-        appName: "cutie-launcher"
-        storeName: "favoriteItems"
-
-        onDataChanged:
-            loadFavoriteApps()  
-    }
     
-    CutieStore {
-        id: homeConfigStore
-        appName: "cutie-home"
-        storeName: "homeConfigs"
-    }
-
+    property var launcherApps: CutieDesktopFileParser.createFilterModel()
     readonly property bool split: true
     readonly property bool merged: false
+
     property bool interfaceMode:
                     homeConfigStore.data && "InterfaceMode" in homeConfigStore.data 
                     ? homeConfigStore.data["InterfaceMode"] 
@@ -127,10 +69,45 @@ Item {
 
         return Math.round(raw * 10) / 10
     }
+    
     property bool panelMode: 
                     homeConfigStore.data && "PanelMode" in homeConfigStore.data  
                     ? homeConfigStore.data["PanelMode"] 
                     : true
+
+    function addNotification(title, body, id) {
+        notifications.append({title: title, body: body, id: id});
+        CutieFeedback.trigger(Application.name, "message-new-instant", {}, -1);
+    }
+
+    function delNotification(id) {
+        for (let c_i = 0; c_i < notifications.count; c_i++){
+            if (notifications.get(c_i).id === id)
+                notifications.remove(c_i);
+        }
+    }
+
+
+    Component.onCompleted: {
+        launcherApps.favoriteKeys = Object.keys(favoriteStore.data || {})
+    }
+
+    CutieStore {
+        id: favoriteStore
+        appName: "cutie-launcher"
+        storeName: "favoriteItems"
+
+        onDataChanged:
+            launcherApps.favoriteKeys = Object.keys(favoriteStore.data || {})
+    }
+
+    CutieStore {
+        id: homeConfigStore
+        appName: "cutie-home"
+        storeName: "homeConfigs"
+    }
+
+   
 
     ForeignToplevelManagerV1 {
         id: toplevelManager
@@ -165,5 +142,4 @@ Item {
     Footer { id: footer }
 
     ListModel { id: notifications }
-    ListModel { id: launcherApps }
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -21,18 +21,22 @@ Item {
             PropertyChanges { target: appSwitcher; opacity: 1 }
             PropertyChanges { target: homeScreen; opacity: 0 }
             PropertyChanges { target: notificationScreen; opacity: 0 }
+            PropertyChanges { target: footer; opacity: 0 }
         },
         State {
             name: "homeScreen"
             PropertyChanges { target: appSwitcher; opacity: 0 }
             PropertyChanges { target: homeScreen; opacity: 1 }
             PropertyChanges { target: notificationScreen; opacity: 0 }
+            PropertyChanges { target: footer; opacity: 1 }
         },
         State {
             name: "notificationScreen"
             PropertyChanges { target: appSwitcher; opacity: 0 }
             PropertyChanges { target: homeScreen; opacity: 0 }
             PropertyChanges { target: notificationScreen; opacity: 1 }
+            PropertyChanges { target: footer; opacity: 0 }
+
         }
     ]
 
@@ -144,6 +148,7 @@ Item {
     NotificationScreen { id: notificationScreen }
     ScreenSwipe { id: screenSwipe }
     HomeScreen { id: homeScreen }
+    Footer { id: footer }
 
     ListModel { id: notifications }
     ListModel { id: launcherApps }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -4,11 +4,13 @@ import QtQuick.Controls
 import QtMultimedia
 import Cutie
 import Cutie.Feedback
+import Cutie.Store
 import Cutie.Wlc
+import Cutie.Desktopfileparser
 
 Item {
     id: root
-    state: "appSwitcher" 
+    state: "homeScreen"
     visible: true
     width: Screen.width
     height: Screen.height
@@ -17,11 +19,19 @@ Item {
         State{
             name: "appSwitcher"
             PropertyChanges { target: appSwitcher; opacity: 1 }
+            PropertyChanges { target: homeScreen; opacity: 0 }
+            PropertyChanges { target: notificationScreen; opacity: 0 }
+        },
+        State {
+            name: "homeScreen"
+            PropertyChanges { target: appSwitcher; opacity: 0 }
+            PropertyChanges { target: homeScreen; opacity: 1 }
             PropertyChanges { target: notificationScreen; opacity: 0 }
         },
         State {
             name: "notificationScreen"
             PropertyChanges { target: appSwitcher; opacity: 0 }
+            PropertyChanges { target: homeScreen; opacity: 0 }
             PropertyChanges { target: notificationScreen; opacity: 1 }
         }
     ]
@@ -30,9 +40,9 @@ Item {
         Transition {
             to: "*"
             NumberAnimation { target: notificationScreen; properties: "opacity"; duration: 300; easing.type: Easing.InOutQuad; }
+            NumberAnimation { target: homeScreen; properties: "opacity"; duration: 300; easing.type: Easing.InOutQuad; }
             NumberAnimation { target: appSwitcher; properties: "opacity"; duration: 300; easing.type: Easing.InOutQuad; }
         }
-
     ]
 
     function addNotification(title, body, id) {
@@ -46,7 +56,64 @@ Item {
                 notifications.remove(c_i);
         }
     }
+
+    function loadFavoriteApps() {
+        console.log("home - Loading Favorite store data using DesktopFileParser...");
+        if (!favoriteStore.data) {
+            console.log("home - Favorite store data is not yet available.");
+            return;
+        }
+        launcherApps.clear();
+        let favoriteKeys = Object.keys(favoriteStore.data);
+        let allAppsModel = CutieDesktopFileParser.fetchAllEntriesModel();
+        if (!allAppsModel) {
+            console.log("home - Error: DesktopFileParser model is null.");
+            return;
+        }
+        console.log("allAppsModel received count:", allAppsModel.rowCount());
+        for (let i = 0; i < allAppsModel.rowCount(); i++) {
+            let index = allAppsModel.index(i, 0);
+            let appName = allAppsModel.data(index, 257);
+            if (favoriteKeys.indexOf(appName) !== -1) {
+                launcherApps.append({
+                    name: appName,
+                    icon: allAppsModel.data(index, 259),
+                    exec: allAppsModel.data(index, 258)
+                });
+            }
+        }
+        console.log("home - Favorite apps loaded successfully. Count:", launcherApps.count);
+    }
+
+
+    Component.onCompleted: {
+        loadFavoriteApps();
+        updateVisibility();            
+    }
+
+    CutieStore {
+        id: favoriteStore
+        appName: "cutie-launcher"
+        storeName: "favoriteItems"
+
+        onDataChanged: {
+            loadFavoriteApps();
+            updateVisibility();
+        }
+    }
+
+    property bool favoriteAppsVisibility: "visibility" in favoriteStore.data ? favoriteStore.data["visibility"] : true
     
+    function updateVisibility() {
+        if (favoriteStore.data) {
+            let favoriteData = favoriteStore.data;
+
+            favoriteAppsVisibility = favoriteData.visibility;
+            console.log("home - Visibility variable updated . Current state:", favoriteAppsVisibility);
+            favoriteStore.data = favoriteData;
+        }
+    }
+
     ForeignToplevelManagerV1 {
         id: toplevelManager
     }
@@ -76,6 +143,8 @@ Item {
     AppSwitcher { id: appSwitcher }
     NotificationScreen { id: notificationScreen }
     ScreenSwipe { id: screenSwipe }
+    HomeScreen { id: homeScreen }
 
     ListModel { id: notifications }
+    ListModel { id: launcherApps }
 }

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -88,7 +88,7 @@ Item {
 
     Component.onCompleted: {
         loadFavoriteApps();
-        updateVisibility();            
+        updateInterfaceMode();            
     }
 
     CutieStore {
@@ -98,19 +98,19 @@ Item {
 
         onDataChanged: {
             loadFavoriteApps();
-            updateVisibility();
+            updateInterfaceMode();
         }
     }
-
-    property bool favoriteAppsVisibility: "visibility" in favoriteStore.data ? favoriteStore.data["visibility"] : true
+    readonly property bool split: true
+    readonly property bool merged: false
+    property bool interfaceMode: "InterfaceMode" in favoriteStore.data ? favoriteStore.data["InterfaceMode"] : merged
     
-    function updateVisibility() {
+    function updateInterfaceMode() {
         if (favoriteStore.data) {
             let favoriteData = favoriteStore.data;
 
-            favoriteAppsVisibility = favoriteData.visibility;
-            console.log("home - Visibility variable updated . Current state:", favoriteAppsVisibility);
-            favoriteStore.data = favoriteData;
+            interfaceMode = favoriteData.InterfaceMode;
+            console.log("home - InterfaceMode updated. Current state:", interfaceMode === split ? "split" : "merged");        
         }
     }
 

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -10,7 +10,7 @@ import Cutie.Desktopfileparser
 
 Item {
     id: root
-    state: "homeScreen"
+    state: "appSwitcher"
     visible: true
     width: Screen.width
     height: Screen.height
@@ -46,6 +46,8 @@ Item {
             NumberAnimation { target: notificationScreen; properties: "opacity"; duration: 300; easing.type: Easing.InOutQuad; }
             NumberAnimation { target: homeScreen; properties: "opacity"; duration: 300; easing.type: Easing.InOutQuad; }
             NumberAnimation { target: appSwitcher; properties: "opacity"; duration: 300; easing.type: Easing.InOutQuad; }
+            NumberAnimation { target: footer; properties: "opacity"; duration: 300; easing.type: Easing.InOutQuad; }
+
         }
     ]
 
@@ -92,7 +94,6 @@ Item {
 
     Component.onCompleted: {
         loadFavoriteApps();
-        updateInterfaceMode();            
     }
 
     CutieStore {
@@ -100,23 +101,36 @@ Item {
         appName: "cutie-launcher"
         storeName: "favoriteItems"
 
-        onDataChanged: {
-            loadFavoriteApps();
-            updateInterfaceMode();
-        }
+        onDataChanged:
+            loadFavoriteApps()  
     }
+    
+    CutieStore {
+        id: homeConfigStore
+        appName: "cutie-home"
+        storeName: "homeConfigs"
+    }
+
     readonly property bool split: true
     readonly property bool merged: false
-    property bool interfaceMode: "InterfaceMode" in favoriteStore.data ? favoriteStore.data["InterfaceMode"] : merged
-    
-    function updateInterfaceMode() {
-        if (favoriteStore.data) {
-            let favoriteData = favoriteStore.data;
+    property bool interfaceMode:
+                    homeConfigStore.data && "InterfaceMode" in homeConfigStore.data 
+                    ? homeConfigStore.data["InterfaceMode"] 
+                    : merged
 
-            interfaceMode = favoriteData.InterfaceMode;
-            console.log("home - InterfaceMode updated. Current state:", interfaceMode === split ? "split" : "merged");        
-        }
+    readonly property real dockScale: {
+        if (!homeConfigStore.data)
+        return 1.0
+
+        const v = homeConfigStore.data.dockScale
+        const raw = (v !== undefined && v > 0) ? v : 1.0
+
+        return Math.round(raw * 10) / 10
     }
+    property bool panelMode: 
+                    homeConfigStore.data && "PanelMode" in homeConfigStore.data  
+                    ? homeConfigStore.data["PanelMode"] 
+                    : true
 
     ForeignToplevelManagerV1 {
         id: toplevelManager

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -51,7 +51,7 @@ Item {
         }
     ]
     
-    property var launcherApps: CutieDesktopFileParser.createFilterModel()
+    property var launcherApps: null
     readonly property bool split: true
     readonly property bool merged: false
 
@@ -89,7 +89,9 @@ Item {
 
 
     Component.onCompleted: {
-        launcherApps.favoriteKeys = Object.keys(favoriteStore.data || {})
+        let model = CutieDesktopFileParser.createFilterModel()
+        model.favoriteKeys = Object.keys(favoriteStore.data || {})
+        launcherApps = model    
     }
 
     CutieStore {

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -4,5 +4,6 @@
         <file>AppSwitcher.qml</file>
         <file>NotificationScreen.qml</file>
         <file>ScreenSwipe.qml</file>
+        <file>HomeScreen.qml</file>
     </qresource>
 </RCC>

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -5,5 +5,6 @@
         <file>NotificationScreen.qml</file>
         <file>ScreenSwipe.qml</file>
         <file>HomeScreen.qml</file>
+        <file>Footer.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This PR introduces user switching functionality to cutie-home, including a new home screen interface and a footer component for launching favorite applications.

## Changes
- **New Components**: Added `HomeScreen.qml` and `Footer.qml` components for the home screen interface
- **Screen Navigation**: Enhanced `ScreenSwipe.qml` to support navigation between home screen, app switcher, and notification screen
- **Favorite Apps**: Integrated favorite apps functionality using CutieStore to manage and display user's favorite applications
- **Configuration**: Added support for home screen configuration including interface mode (split/merged), dock scaling, and panel mode settings
- **File Management**: Updated `qml.qrc` to include the new QML files